### PR TITLE
Add native targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,20 @@ build/
 out/
 .idea
 local.properties
+
+### Gradle template
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle/wrapper/gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,4 +1,4 @@
 object Versions {
     const val jacocoPlugin = "0.8.5"
-    const val assertk = "0.24"
+    const val assertk = "0.25"
 }

--- a/buildSrc/src/main/kotlin/mpp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/mpp-module.gradle.kts
@@ -11,6 +11,14 @@ plugins {
     id("maven-publish")
 }
 
+val nativeTargets = arrayOf(
+    "linuxX64",
+    "macosX64", "macosArm64",
+    "iosArm32", "iosArm64", "iosX64", "iosSimulatorArm64",
+    "tvosArm64", "tvosX64", "tvosSimulatorArm64",
+    "watchosArm32", "watchosArm64", "watchosX86", "watchosX64", "watchosSimulatorArm64",
+)
+
 kotlin {
     explicitApi()
     targets {
@@ -39,6 +47,9 @@ kotlin {
                     }
                 }
             }
+        }
+        for (target in nativeTargets) {
+            targets.add(presets.getByName(target).createTarget(target))
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ kotlin.incremental=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.enableDependencyPropagation=false
+kotlin.native.binary.memoryModel=experimental
 
 ## Kapt Build Settings
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ kapt.use.worker.api=true
 
 ## Kotlin Gradle Plugin
 
-kgp=1.5.10
+kgp=1.6.21
 
 ## Gradle Plugins
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I added all native targets that kassert supports which are:
```
    "linuxX64",
    "macosX64", "macosArm64",
    "iosArm32", "iosArm64", "iosX64", "iosSimulatorArm64",
    "tvosArm64", "tvosX64", "tvosSimulatorArm64",
    "watchosArm32", "watchosArm64", "watchosX86", "watchosX64", 
    "watchosSimulatorArm64",
```